### PR TITLE
Add configuration options

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -23,6 +23,43 @@ function islandora_usage_stats_callbacks_admin_form() {
     '#default_value' => variable_get('islandora_usage_stats_callbacks_legacy_stats_file_location', ''),
   );
 
+/* This is for later
+  $all_cmodels = islandora_get_content_models();
+*/ 
+
+  $form['content_model_wrapper'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Configure which DSID downloads will be tracked.'),
+    '#collapsible' => FALSE,
+    '#collapsed' => FALSE,
+  );
+
+  $default_dsids = "ir:citationCModel|PDF
+ir:thesisCModel|PDF
+islandora:sp_pdf|OBJ
+islandora:sp_basic_image|OBJ
+islandora:sp_large_image_cmodel|OBJ
+islandora:binaryObjectCModel|OBJ
+islandora:sp_videoCModel|MP4
+islandora:sp-audioCModel|PROXY_MP3
+islandora:collectionCModel|FALSE
+islandora:compoundCModel|FALSE
+islandora:newspaperIssueCModel|PDF
+islandora:newspaperPageCModel|OBJ
+islandora:sp_web_archive|OBJ
+islandora:sp_disk_image|OBJ
+islandora:pageCModel|OBJ
+islandora:bookCModel|PDF\nislandora:newspaperCModel|PDF";
+
+  $form['content_model_wrapper']['islandora_usage_stats_callbacks_cmodel_dsids'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Download DSIDs to track'),
+    '#rows' => 10,
+    '#default_value' => variable_get('islandora_usage_stats_callbacks_cmodel_dsids', $default_dsids),
+    '#description' => t("Place each CModel and DSID pair, separated by a |, on its own line. Enter FALSE for CModels with no downloadable datastreams."),
+  );
+
+
   $form['save_configuration'] = array(
     '#type' => 'submit',
     '#name' => 'saveConfiguration',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,23 +34,8 @@ function islandora_usage_stats_callbacks_admin_form() {
     '#collapsed' => FALSE,
   );
 
-  $default_dsids = "ir:citationCModel|PDF
-ir:thesisCModel|PDF
-islandora:sp_pdf|OBJ
-islandora:sp_basic_image|OBJ
-islandora:sp_large_image_cmodel|OBJ
-islandora:binaryObjectCModel|OBJ
-islandora:sp_videoCModel|MP4
-islandora:sp-audioCModel|PROXY_MP3
-islandora:collectionCModel|FALSE
-islandora:compoundCModel|FALSE
-islandora:newspaperIssueCModel|PDF
-islandora:newspaperPageCModel|OBJ
-islandora:sp_web_archive|OBJ
-islandora:sp_disk_image|OBJ
-islandora:pageCModel|OBJ
-islandora:bookCModel|PDF\nislandora:newspaperCModel|PDF";
-
+  module_load_include('inc', 'islandora_usage_stats_callbacks', 'includes/utilities');
+  $default_dsids = islandora_usage_stats_callbacks_set_default_dsids();
   $form['content_model_wrapper']['islandora_usage_stats_callbacks_cmodel_dsids'] = array(
     '#type' => 'textarea',
     '#title' => t('Download DSIDs to track'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -11,7 +11,9 @@
  *   The default DSID assignments
  */
 function islandora_usage_stats_callbacks_set_default_dsids() {
-  $default_dsids = "ir:citationCModel|PDF\nir:thesisCModel|PDF\nislandora:sp_pdf|OBJ
+  $default_dsids = "ir:citationCModel|PDF
+ir:thesisCModel|PDF
+islandora:sp_pdf|OBJ
 islandora:sp_basic_image|OBJ
 islandora:sp_large_image_cmodel|OBJ
 islandora:binaryObjectCModel|OBJ

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Utility functions.
+ */
+
+/* Set the default CModel and DSID assignments.
+ *
+ * @return string
+ *   The default DSID assignments
+ */
+function islandora_usage_stats_callbacks_set_default_dsids() {
+  $default_dsids = "ir:citationCModel|PDF
+ir:thesisCModel|PDF
+islandora:sp_pdf|OBJ
+islandora:sp_basic_image|OBJ
+islandora:sp_large_image_cmodel|OBJ
+islandora:binaryObjectCModel|OBJ
+islandora:sp_videoCModel|MP4
+islandora:sp-audioCModel|PROXY_MP3
+islandora:collectionCModel|FALSE
+islandora:compoundCModel|FALSE
+islandora:newspaperIssueCModel|PDF
+islandora:newspaperPageCModel|OBJ
+islandora:sp_web_archive|OBJ
+islandora:sp_disk_image|OBJ
+islandora:pageCModel|OBJ
+islandora:bookCModel|PDF\nislandora:newspaperCModel|PDF";
+  return $default_dsids;
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -11,9 +11,7 @@
  *   The default DSID assignments
  */
 function islandora_usage_stats_callbacks_set_default_dsids() {
-  $default_dsids = "ir:citationCModel|PDF
-ir:thesisCModel|PDF
-islandora:sp_pdf|OBJ
+  $default_dsids = "ir:citationCModel|PDF\nir:thesisCModel|PDF\nislandora:sp_pdf|OBJ
 islandora:sp_basic_image|OBJ
 islandora:sp_large_image_cmodel|OBJ
 islandora:binaryObjectCModel|OBJ

--- a/islandora_usage_stats_callbacks.install
+++ b/islandora_usage_stats_callbacks.install
@@ -9,5 +9,9 @@
  * Implements hook_uninstall().
  */
 function islandora_usage_stats_callbacks_uninstall() {
-  variable_del('islandora_usage_stats_callbacks_legacy_stats_file_location');
+  $vars = array(
+    'islandora_usage_stats_callbacks_cmodel_dsids',
+    'islandora_usage_stats_callbacks_legacy_stats_file_location',
+  );
+  array_walk($vars, 'variable_del');
 }

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -102,7 +102,11 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
   $ids = array();
   $ids['pid'] = $pid;
   $ids['cmodel'] = islandora_object_load($pid)->models[0];
-  $dsids = variable_get(islandora_usage_stats_callbacks_cmodel_dsids,'ir:citationCModel|PDF\nir:thesisCModel|PDF\nislandora:sp_pdf|OBJ\nislandora:sp_basic_image|OBJ\nislandora:sp_large_image_cmodel|OBJ\nislandora:binaryObjectCModel|OBJnislandora:sp_videoCModel|MP4\nislandora:sp-audioCModel|PROXY_MP3nislandora:collectionCModel|FALSE\nislandora:compoundCModel|FALSE\nislandora:newspaperIssueCModel|PDF\nislandora:newspaperPageCModel|OBJ\nislandora:sp_web_archive|OBJ\nislandora:sp_disk_image|OBJ\nislandora:pageCModel|OBJ\nislandora:bookCModel|PDF\nislandora:newspaperCModel|PDF');
+
+  module_load_include('inc', 'islandora_usage_stats_callbacks', 'includes/utilities');
+  $default_dsids = islandora_usage_stats_callbacks_set_default_dsids();
+
+  $dsids = variable_get(islandora_usage_stats_callbacks_cmodel_dsids, $default_dsids);
   $cmodel_dsids = array();
 
   // Convert configured DSIDs into an array

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -106,13 +106,14 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
   module_load_include('inc', 'islandora_usage_stats_callbacks', 'includes/utilities');
   $default_dsids = islandora_usage_stats_callbacks_set_default_dsids();
   $dsids = variable_get(islandora_usage_stats_callbacks_cmodel_dsids, $default_dsids);
-  $dsid = array();
   $cmodel_dsids = array();
+  $rows = array();
 
   // Convert configured DSIDs into an array
-  foreach (explode("\n", $dsids) as $pair) {
-    $dsid = explode('|', $pair);
-    $cmodel_dsids[$dsid[0]] = $dsid[1];
+  $rows = preg_split("/\\r\\n|\\r|\\n/", $dsids);
+  foreach ($rows as $pair) {
+    $rows = explode('|', $pair);
+    $cmodel_dsids[$rows[0]] = $rows[1];
   }
 
   if ($ids['cmodel'] == '') {

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -105,12 +105,11 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
 
   module_load_include('inc', 'islandora_usage_stats_callbacks', 'includes/utilities');
   $default_dsids = islandora_usage_stats_callbacks_set_default_dsids();
-
   $dsids = variable_get(islandora_usage_stats_callbacks_cmodel_dsids, $default_dsids);
   $cmodel_dsids = array();
 
   // Convert configured DSIDs into an array
-  foreach (explode('\n', $dsids) as $pair) {
+  foreach (explode("\n", $dsids) as $pair) {
     $dsid = explode('|', $pair);
     $cmodel_dsids[$dsid[0]] = $dsid[1];
   }

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -106,6 +106,7 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
   module_load_include('inc', 'islandora_usage_stats_callbacks', 'includes/utilities');
   $default_dsids = islandora_usage_stats_callbacks_set_default_dsids();
   $dsids = variable_get(islandora_usage_stats_callbacks_cmodel_dsids, $default_dsids);
+  $dsid = array();
   $cmodel_dsids = array();
 
   // Convert configured DSIDs into an array

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -106,9 +106,9 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
   $cmodel_dsids = array();
 
   // Convert configured DSIDs into an array
-  foreach(explode('\n',$dsids) as $pair){
-    $x=explode('|',$pair);
-    $cmodel_dsids[$x[0]]=$x[1];
+  foreach (explode('\n', $dsids) as $pair) {
+    $dsid = explode('|', $pair);
+    $cmodel_dsids[$dsid[0]] = $dsid[1];
   }
 
   if ($ids['cmodel'] == '') {

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -119,7 +119,7 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
                         'islandora:pageCModel' => 'OBJ',
                         'islandora:bookCModel' => 'PDF',
                         'islandora:newspaperCModel' => 'PDF');
- 
+print_r($cmodel_dsids); 
   if ($ids['cmodel'] == '') {
     echo json_encode(array('error' => "PID '${ids['pid']}' does not exist")); 
     drupal_exit();

--- a/islandora_usage_stats_callbacks.module
+++ b/islandora_usage_stats_callbacks.module
@@ -102,24 +102,15 @@ function islandora_usage_stats_callbacks_get_object_ids($pid) {
   $ids = array();
   $ids['pid'] = $pid;
   $ids['cmodel'] = islandora_object_load($pid)->models[0];
-  $cmodel_dsids = array('ir:citationCModel' => 'PDF',
-                        'ir:thesisCModel' => 'PDF',
-                        'islandora:sp_pdf' => 'OBJ',
-                        'islandora:sp_basic_image' => 'OBJ',
-                        'islandora:sp_large_image_cmodel' => 'OBJ',
-                        'islandora:binaryObjectCModel' => 'OBJ',
-                        'islandora:sp_videoCModel' => 'MP4',
-                        'islandora:sp-audioCModel' => 'PROXY_MP3',
-                        'islandora:collectionCModel' => FALSE,
-                        'islandora:compoundCModel' => FALSE,
-                        'islandora:newspaperIssueCModel' => 'PDF',
-                        'islandora:newspaperPageCModel' => 'OBJ',
-                        'islandora:sp_web_archive' => 'OBJ',
-                        'islandora:sp_disk_image' => 'OBJ',
-                        'islandora:pageCModel' => 'OBJ',
-                        'islandora:bookCModel' => 'PDF',
-                        'islandora:newspaperCModel' => 'PDF');
-print_r($cmodel_dsids); 
+  $dsids = variable_get(islandora_usage_stats_callbacks_cmodel_dsids,'ir:citationCModel|PDF\nir:thesisCModel|PDF\nislandora:sp_pdf|OBJ\nislandora:sp_basic_image|OBJ\nislandora:sp_large_image_cmodel|OBJ\nislandora:binaryObjectCModel|OBJnislandora:sp_videoCModel|MP4\nislandora:sp-audioCModel|PROXY_MP3nislandora:collectionCModel|FALSE\nislandora:compoundCModel|FALSE\nislandora:newspaperIssueCModel|PDF\nislandora:newspaperPageCModel|OBJ\nislandora:sp_web_archive|OBJ\nislandora:sp_disk_image|OBJ\nislandora:pageCModel|OBJ\nislandora:bookCModel|PDF\nislandora:newspaperCModel|PDF');
+  $cmodel_dsids = array();
+
+  // Convert configured DSIDs into an array
+  foreach(explode('\n',$dsids) as $pair){
+    $x=explode('|',$pair);
+    $cmodel_dsids[$x[0]]=$x[1];
+  }
+
   if ($ids['cmodel'] == '') {
     echo json_encode(array('error' => "PID '${ids['pid']}' does not exist")); 
     drupal_exit();


### PR DESCRIPTION
This PR is based on yours, @mjordan, so it could be merged into your PR before yours gets merged into master.

I'd consider this a first step - getting the config functionality in - before the second step of using auto-generated CModel lists and automatically-populated DSIDs.

Note that the default for islandora_usage_stats_callbacks_cmodel_dsids is absurdly long; suggestions for how to shorten it on line 105 would be welcomed.